### PR TITLE
Ensure that a resource id is always available in the update case, req…

### DIFF
--- a/src/dataServices/dynamoDbBundleServiceHelper.ts
+++ b/src/dataServices/dynamoDbBundleServiceHelper.ts
@@ -73,10 +73,7 @@ export default class DynamoDbBundleServiceHelper {
                     // Create new entry with status = PENDING
                     // When updating a resource, create a new Document for that resource
                     // If availabe the id of the request shall be used (condition update use case)
-                    let { id } = request;
-                    if (!id) {
-                        id = request.resource.id;
-                    }
+                    const id = request.id || request.resource.id;
                     const vid = (idToVersionId[id] || 0) + 1;
                     const Item = DynamoDbUtil.prepItemForDdbInsert(
                         request.resource,

--- a/src/dataServices/dynamoDbBundleServiceHelper.ts
+++ b/src/dataServices/dynamoDbBundleServiceHelper.ts
@@ -72,7 +72,11 @@ export default class DynamoDbBundleServiceHelper {
                 case 'update': {
                     // Create new entry with status = PENDING
                     // When updating a resource, create a new Document for that resource
-                    const { id } = request.resource;
+                    // If availabe the id of the request shall be used (condition update use case)
+                    let { id } = request;
+                    if (!id) {
+                        id = request.resource.id;
+                    }
                     const vid = (idToVersionId[id] || 0) + 1;
                     const Item = DynamoDbUtil.prepItemForDdbInsert(
                         request.resource,
@@ -92,6 +96,7 @@ export default class DynamoDbBundleServiceHelper {
                     const { stagingResponse, itemLocked } = this.addStagingResponseAndItemsLocked(request.operation, {
                         ...request.resource,
                         meta: { ...Item.meta },
+                        id,
                     });
                     newBundleEntryResponses = newBundleEntryResponses.concat(stagingResponse);
                     newLocks = newLocks.concat(itemLocked);


### PR DESCRIPTION
Description of changes:
In the update case of generateStagingRequests() it must be ensured that a resource id is always available. This wasn't the case for conditional update. The resource itself did not yet have a resource id as property. In that case resource id is only available in the request object is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.