### PR TITLE
Update node 12 to 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/jest": "^26.0.19",
     "@types/lodash": "^4.14.161",
     "@types/mime-types": "^2.1.0",
-    "@types/node": "^12",
+    "@types/node": "^14",
     "@types/promise.allsettled": "^1.0.3",
     "@types/sinon": "^9.0.0",
     "@types/uuid": "^3.4.7",
@@ -94,6 +94,6 @@
     "url": "git://github.com/awslabs/fhir-works-on-aws-persistence-ddb.git"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Updates node, as AWS deprecated node 12 for AWS Lambda. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.